### PR TITLE
0.1.3

### DIFF
--- a/CosmicHorrorFishingBuddies/HarvestPOISync/NetworkStockableHarvestPOI.cs
+++ b/CosmicHorrorFishingBuddies/HarvestPOISync/NetworkStockableHarvestPOI.cs
@@ -26,13 +26,17 @@ namespace CosmicHorrorFishingBuddies.HarvestPOISync
 		{
 			try
 			{
-				HarvestPOIPatches.disabled = true;
+				// Do not allow syncing of spots which do not restock
+				if (Target.harvestable.GetDoesRestock())
+				{
+					HarvestPOIPatches.disabled = true;
 
-				var dStock = count - Target.Stock;
-				Target.harvestable.AddStock(dStock, false);
-				Target.OnStockUpdated();
+					var dStock = count - Target.Stock;
+					Target.harvestable.AddStock(dStock, false);
+					Target.OnStockUpdated();
 
-				HarvestPOIPatches.disabled = false;
+					HarvestPOIPatches.disabled = false;
+				}
 			}
 			catch (Exception e)
 			{

--- a/CosmicHorrorFishingBuddies/mod_meta.json
+++ b/CosmicHorrorFishingBuddies/mod_meta.json
@@ -2,7 +2,7 @@
 	"Name": "Cosmic Horror Fishing Buddies",
 	"ModGUID": "xen.cosmichorrorfishingbuddies",
 	"Author": "xen-42",
-	"Version": "0.1.2",
+	"Version": "0.1.3",
 	"ModAssembly": "CosmicHorrorFishingBuddies.dll",
 	"MinWinchVersion": "alpha-1.3",
 	"Entrypoint": "CosmicHorrorFishingBuddies.Loader/Initialize"


### PR DESCRIPTION
Fixes:
- Fishing/dredging spots that do not restock will no longer be synced. Means both players can get unique/quest items.