### PR TITLE
Iron Rig Boat Support

### DIFF
--- a/CosmicHorrorFishingBuddies/Core/CFBCore.cs
+++ b/CosmicHorrorFishingBuddies/Core/CFBCore.cs
@@ -45,9 +45,9 @@ namespace CosmicHorrorFishingBuddies.Core
 
 				new Harmony(nameof(CFBCore)).PatchAll();
 
+				gameObject.AddComponent<UIHelper>();
 				gameObject.AddComponent<CFBNetworkManager>();
 				gameObject.AddComponent<CFBSceneManager>();
-				gameObject.AddComponent<UIHelper>();
 				gameObject.AddComponent<DebugController>();
 
 				Application.logMessageReceived += Application_logMessageReceived;

--- a/CosmicHorrorFishingBuddies/Core/CFBCore.cs
+++ b/CosmicHorrorFishingBuddies/Core/CFBCore.cs
@@ -45,10 +45,10 @@ namespace CosmicHorrorFishingBuddies.Core
 
 				new Harmony(nameof(CFBCore)).PatchAll();
 
+				gameObject.AddComponent<DebugController>();
 				gameObject.AddComponent<UIHelper>();
 				gameObject.AddComponent<CFBNetworkManager>();
 				gameObject.AddComponent<CFBSceneManager>();
-				gameObject.AddComponent<DebugController>();
 
 				Application.logMessageReceived += Application_logMessageReceived;
 			}

--- a/CosmicHorrorFishingBuddies/Core/CFBNetworkManager.cs
+++ b/CosmicHorrorFishingBuddies/Core/CFBNetworkManager.cs
@@ -1,4 +1,5 @@
-﻿using CosmicHorrorFishingBuddies.Extensions;
+﻿using CosmicHorrorFishingBuddies.Debugging;
+using CosmicHorrorFishingBuddies.Extensions;
 using CosmicHorrorFishingBuddies.HarvestPOISync;
 using CosmicHorrorFishingBuddies.PlayerSync;
 using CosmicHorrorFishingBuddies.PlayerSync.AbilitySync;
@@ -43,6 +44,8 @@ namespace CosmicHorrorFishingBuddies.Core
 				gameObject.SetActive(false);
 
 				_kcpTransport = gameObject.AddComponent<KcpTransport>();
+				// KCP uses milliseconds
+				_kcpTransport.Timeout = DebugController.Instance.Timeout * 1000;
 
 				// EPIC
 				_epicApiKey = ScriptableObject.CreateInstance<EosApiKey>();
@@ -59,6 +62,7 @@ namespace CosmicHorrorFishingBuddies.Core
 				eosSdkComponent.epicLoggerLevel = Epic.OnlineServices.Logging.LogLevel.VeryVerbose;
 
 				var eosTransport = gameObject.AddComponent<EosTransport>();
+				eosTransport.timeout = DebugController.Instance.Timeout;
 				_epicTransport = eosTransport;
 
 				// PREFABS

--- a/CosmicHorrorFishingBuddies/Core/CFBSpawnManager.cs
+++ b/CosmicHorrorFishingBuddies/Core/CFBSpawnManager.cs
@@ -70,7 +70,7 @@ namespace CosmicHorrorFishingBuddies.Core
 			}
 			catch (Exception e)
 			{
-				CFBCore.LogError($"Couldn't spawn network bait {e}");
+				CFBCore.LogError($"Couldn't spawn network crab pot {e}");
 			}
 		}
 

--- a/CosmicHorrorFishingBuddies/CosmicHorrorFishingBuddies.csproj
+++ b/CosmicHorrorFishingBuddies/CosmicHorrorFishingBuddies.csproj
@@ -32,7 +32,7 @@
 		<Reference Include="..\Mirror\*.dll" />
 		<PackageReference Include="HarmonyX" Version="2.10.2" />
 		<PackageReference Include="DredgeGameLibs" Version="1.5.1" />
-		<PackageReference Include="Winch" Version="0.4.0" />
+		<PackageReference Include="Winch" Version="0.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/CosmicHorrorFishingBuddies/CosmicHorrorFishingBuddies.csproj
+++ b/CosmicHorrorFishingBuddies/CosmicHorrorFishingBuddies.csproj
@@ -31,8 +31,8 @@
 	<ItemGroup>
 		<Reference Include="..\Mirror\*.dll" />
 		<PackageReference Include="HarmonyX" Version="2.10.2" />
-		<PackageReference Include="DredgeGameLibs" Version="1.5.1" />
-		<PackageReference Include="Winch" Version="0.5.0" />
+		<PackageReference Include="DredgeGameLibs" Version="1.5.3" />
+		<PackageReference Include="Winch" Version="0.5.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/CosmicHorrorFishingBuddies/Debugging/DebugController.cs
+++ b/CosmicHorrorFishingBuddies/Debugging/DebugController.cs
@@ -23,6 +23,9 @@ internal class DebugController : MonoBehaviour
 	public bool QuickLoad = false;
 	private bool _hasQuickLoaded = false;
 
+	[JsonProperty]
+	public int Timeout = 25;
+
 	public void Awake()
 	{
 		Instance = this;

--- a/CosmicHorrorFishingBuddies/HarvestPOISync/NetworkPlacedHarvestPOI.cs
+++ b/CosmicHorrorFishingBuddies/HarvestPOISync/NetworkPlacedHarvestPOI.cs
@@ -35,7 +35,7 @@ namespace CosmicHorrorFishingBuddies.HarvestPOISync
 			{
 				var yRotation = crabPotData.yRotation;
 				var position = new Vector3(crabPotData.x, 0f, crabPotData.z);
-				var gameObject = GameSceneInitializer.Instance.placedPOIPrefab.InstantiateInactive();
+				var gameObject = GameSceneInitializer.Instance.GetPlacedHarvestPOIPrefabFromPotItemData(crabPotData.deployableItemId).InstantiateInactive();
 				gameObject.transform.parent = GameSceneInitializer.Instance.harvestPoiContainer.transform;
 				gameObject.transform.position = position;
 				gameObject.transform.eulerAngles = new Vector3(0f, yRotation, 0f);

--- a/CosmicHorrorFishingBuddies/PlayerSync/AbilitySync/RemoteLightAbility.cs
+++ b/CosmicHorrorFishingBuddies/PlayerSync/AbilitySync/RemoteLightAbility.cs
@@ -52,23 +52,28 @@ namespace CosmicHorrorFishingBuddies.PlayerSync.AbilitySync
 
 		public void RefreshLights()
 		{
-			try
-			{
-				_networkPlayer.remotePlayerBoatGraphics.CurrentBoatModelProxy.SetLightStrength(IsActive ? 4f : 0f);
+			Delay.RunWhen(
+				() => _networkPlayer.remotePlayerBoatGraphics.boatModelProxies != null && _networkPlayer.remotePlayerBoatGraphics.boatModelProxies.Length > 0, 
+				() => {
+					try
+					{
+						_networkPlayer.remotePlayerBoatGraphics.CurrentBoatModelProxy.SetLightStrength(IsActive ? 4f : 0f);
 
-				foreach (var light in _networkPlayer.remotePlayerBoatGraphics.CurrentBoatModelProxy.Lights)
-				{
-					light.SetActive(IsActive);
+						foreach (var light in _networkPlayer.remotePlayerBoatGraphics.CurrentBoatModelProxy.Lights)
+						{
+							light.SetActive(IsActive);
+						}
+						foreach (var lightBeam in _networkPlayer.remotePlayerBoatGraphics.CurrentBoatModelProxy.LightBeams)
+						{
+							lightBeam.SetActive(IsActive);
+						}
+					}
+					catch (Exception e)
+					{
+						CFBCore.LogError($"Failed to refresh lights {e}");
+					}
 				}
-				foreach (var lightBeam in _networkPlayer.remotePlayerBoatGraphics.CurrentBoatModelProxy.LightBeams)
-				{
-					lightBeam.SetActive(IsActive);
-				}
-			}
-			catch (Exception e)
-			{
-				CFBCore.LogError(e);
-			}
+			);
 		}
 	}
 }

--- a/CosmicHorrorFishingBuddies/PlayerSync/PlayerTransformSync.cs
+++ b/CosmicHorrorFishingBuddies/PlayerSync/PlayerTransformSync.cs
@@ -85,7 +85,7 @@ namespace CosmicHorrorFishingBuddies.PlayerSync
 				// SmokeColumn shares a material between all players and gets weird because of it
 				foreach (var smokeColumn in PlayerPrefab.GetComponentsInChildren<SmokeColumn>(true))
 				{
-					var mat = new Material(smokeColumn.smokeMaterial);
+					var mat = new Material(smokeColumn.line.material);
 					smokeColumn.line.material = mat;
 					smokeColumn.smokeMaterial = mat;
 				}

--- a/CosmicHorrorFishingBuddies/PlayerSync/PlayerTransformSync.cs
+++ b/CosmicHorrorFishingBuddies/PlayerSync/PlayerTransformSync.cs
@@ -60,6 +60,7 @@ namespace CosmicHorrorFishingBuddies.PlayerSync
 				CopyBoat(PlayerPrefab, GameManager.Instance.Player.transform.Find("Boat2"));
 				CopyBoat(PlayerPrefab, GameManager.Instance.Player.transform.Find("Boat3"));
 				CopyBoat(PlayerPrefab, GameManager.Instance.Player.transform.Find("Boat4"));
+				CopyBoat(PlayerPrefab, GameManager.Instance.Player.transform.Find("Boat5"));
 
 				// Attached rigidbodies are really weird. Have to set up some networkrigidbody stuff in the future
 				foreach (var rigidBody in PlayerPrefab.gameObject.GetComponentsInChildren<Rigidbody>(true).Select(x => x.gameObject))

--- a/CosmicHorrorFishingBuddies/PlayerSync/RemoteBoatGraphics.cs
+++ b/CosmicHorrorFishingBuddies/PlayerSync/RemoteBoatGraphics.cs
@@ -48,9 +48,10 @@ namespace CosmicHorrorFishingBuddies.PlayerSync
 		private readonly SyncList<int> _tier2Children = new();
 		private readonly SyncList<int> _tier3Children = new();
 		private readonly SyncList<int> _tier4Children = new();
+		private readonly SyncList<int> _tier5Children = new();
 
 		[Command]
-		private void SetActiveChildren(int[] tier1, int[] tier2, int[] tier3, int[] tier4)
+		private void SetActiveChildren(int[] tier1, int[] tier2, int[] tier3, int[] tier4, int[] tier5)
 		{
 			_tier1Children.Clear();
 			_tier1Children.AddRange(tier1);
@@ -63,6 +64,9 @@ namespace CosmicHorrorFishingBuddies.PlayerSync
 
 			_tier4Children.Clear();
 			_tier4Children.AddRange(tier4);
+
+			_tier5Children.Clear();
+			_tier5Children.AddRange(tier5);
 
 			RpcRefreshActiveChildren();
 		}
@@ -143,11 +147,12 @@ namespace CosmicHorrorFishingBuddies.PlayerSync
 			var tier2 = GameManager.Instance.Player._allBoatModelProxies[1].gameObject.GetChildren().FindIndices(x => x.activeInHierarchy).ToArray();
 			var tier3 = GameManager.Instance.Player._allBoatModelProxies[2].gameObject.GetChildren().FindIndices(x => x.activeInHierarchy).ToArray();
 			var tier4 = GameManager.Instance.Player._allBoatModelProxies[3].gameObject.GetChildren().FindIndices(x => x.activeInHierarchy).ToArray();
+			var tier5 = GameManager.Instance.Player._allBoatModelProxies[4].gameObject.GetChildren().FindIndices(x => x.activeInHierarchy).ToArray();
 
-			SetActiveChildren(tier1, tier2, tier3, tier4);
+			SetActiveChildren(tier1, tier2, tier3, tier4, tier5);
 		}
 
-		private int GetLocalUpgradeTier() => Mathf.Clamp(GameManager.Instance.Player._allBoatModelProxies.IndexOf(GameManager.Instance.Player.BoatModelProxy), 0, 3);
+		private int GetLocalUpgradeTier() => Mathf.Clamp(GameManager.Instance.Player._allBoatModelProxies.IndexOf(GameManager.Instance.Player.BoatModelProxy), 0, 4);
 
 		public void OnDestroy()
 		{
@@ -255,6 +260,7 @@ namespace CosmicHorrorFishingBuddies.PlayerSync
 				RefreshChildrenForTier(boatModelProxies[1], _tier2Children);
 				RefreshChildrenForTier(boatModelProxies[2], _tier3Children);
 				RefreshChildrenForTier(boatModelProxies[3], _tier4Children);
+				RefreshChildrenForTier(boatModelProxies[4], _tier5Children);
 			}
 		}
 

--- a/CosmicHorrorFishingBuddies/UI/UIHelper.cs
+++ b/CosmicHorrorFishingBuddies/UI/UIHelper.cs
@@ -124,7 +124,13 @@ namespace CosmicHorrorFishingBuddies.UI
 		{
 			var newButton = _buttonPrefab.InstantiateInactive();
 			newButton.name = $"{text}_Button";
-			newButton.GetComponentInChildren<TextMeshProUGUI>().text = text;
+			var textUI = newButton.GetComponentInChildren<TextMeshProUGUI>();
+			textUI.text = text;
+			textUI.enabled = true;
+			var fontBypass = textUI.gameObject.GetOrAddComponent<LocalizeFontBypass>();
+			fontBypass.textField = textUI;
+			fontBypass.tableString = "Fonts";
+			fontBypass.tableEntryString = "DefaultFont";
 			newButton.GetComponent<BasicButtonWrapper>().OnClick = onClick;
 
 			newButton.transform.parent = parent;

--- a/CosmicHorrorFishingBuddies/mod_meta.json
+++ b/CosmicHorrorFishingBuddies/mod_meta.json
@@ -4,6 +4,6 @@
 	"Author": "xen-42",
 	"Version": "0.3.0",
 	"ModAssembly": "CosmicHorrorFishingBuddies.dll",
-	"MinWinchVersion": "0.4.0",
+	"MinWinchVersion": "0.5.0",
 	"Entrypoint": "CosmicHorrorFishingBuddies.Loader/Initialize"
 }


### PR DESCRIPTION
I was meant to do this pr 3 months ago but I forgot

- Boat items and the upgrade from Iron Rig DLC now visually appear for others
   - Tier 5 Hull
   - Material Pot
   - Siphon Trawler & Material Harvester
- Added timeout debug settings
- Whatever else I did, I don’t remember.